### PR TITLE
Use the generic URL for SPI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Anima is an animation framework for iOS, tvOS, and macOS. It lets you animate properties using spring, easing and decay animations.
 
-**For a full documentation take a look at the** [Online Documentation](https://swiftpackageindex.com/flocked/Anima/main/documentation/anima).
+**For a full documentation take a look at the** [Online Documentation](https://swiftpackageindex.com/flocked/Anima/documentation/anima).
 
 ## Animatable Properties
 


### PR DESCRIPTION
Hi, and thanks for using SPI to host your documentation!

I was just looking at your repo and clicked the link and it went to the [`main` specific documentation](https://swiftpackageindex.com/flocked/Anima/main/documentation/anima), which is now showing out of date as you did a release since then.

There is a link that will always be up to date:

https://swiftpackageindex.com/flocked/Anima/documentation/anima

It redirects to the latest version of documentation. Currently 1.0.5.